### PR TITLE
Add interpolation to MinimalTsit5 and cleanify the code more

### DIFF
--- a/src/simple_tsit5_integrator/benchmarks.jl
+++ b/src/simple_tsit5_integrator/benchmarks.jl
@@ -1,4 +1,23 @@
 using BenchmarkTools, OrdinaryDiffEq
+
+function loop(u, p, t)
+    @inbounds begin
+        σ = p[1]; ρ = p[2]; β = p[3]
+        du1 = σ*(u[2]-u[1])
+        du2 = u[1]*(ρ-u[3]) - u[2]
+        du3 = u[1]*u[2] - β*u[3]
+        return SVector{3}(du1, du2, du3)
+    end
+end
+function liip(du, u, p, t)
+    σ = p[1]; ρ = p[2]; β = p[3]
+    du[1] = σ*(u[2]-u[1])
+    du[2] = u[1]*(ρ-u[3]) - u[2]
+    du[3] = u[1]*u[2] - β*u[3]
+    return nothing
+end
+
+
 function bench()
     u0 = 10ones(3)
     dt = 0.01

--- a/src/simple_tsit5_integrator/benchmarks.jl
+++ b/src/simple_tsit5_integrator/benchmarks.jl
@@ -56,3 +56,31 @@ function bench()
 end
 
 bench()
+
+function bench_only_step()
+  u0 = 10ones(3)
+  dt = 0.01
+  oop = init(SimpleDiffEq.MinimalTsit5(), loop, false, SVector{3}(u0), 0.0, dt, [10, 28, 8/3])
+  DiffEqBase.step!(oop)
+  iip = init(SimpleDiffEq.MinimalTsit5(), liip, true, u0, 0.0, dt, [10, 28, 8/3])
+  DiffEqBase.step!(iip)
+  odeoop = ODEProblem{false}(loop, SVector{3}(u0), (0.0, Inf),  [10, 28, 8/3])
+  deoop = DiffEqBase.init(odeoop, Tsit5();
+  adaptive = false, save_everystep = false, dt = dt, maxiters = Inf)
+  DiffEqBase.step!(deoop)
+  odeiip = ODEProblem{true}(liip, u0, (0.0, Inf),  [10, 28, 8/3])
+  deiip = DiffEqBase.init(odeiip, Tsit5();
+  adaptive = false, save_everystep = false, dt = dt, maxiters = Inf)
+  DiffEqBase.step!(deiip)
+  println("Minimal integrator times")
+  println("In-place time")
+  @btime DiffEqBase.step!($iip)
+  println("Out of place time")
+  @btime DiffEqBase.step!($oop)
+  println("Standard Tsit5 times")
+  println("In-place time")
+  @btime OrdinaryDiffEq.perform_step!($deiip,$(deiip.cache))
+  println("Out of place time")
+  @btime OrdinaryDiffEq.perform_step!($deoop,$(deoop.cache))
+end
+bench_only_step()

--- a/src/simple_tsit5_integrator/profile_test.jl
+++ b/src/simple_tsit5_integrator/profile_test.jl
@@ -1,0 +1,58 @@
+function loop(u, p, t)
+    @inbounds begin
+        σ = p[1]; ρ = p[2]; β = p[3]
+        du1 = σ*(u[2]-u[1])
+        du2 = u[1]*(ρ-u[3]) - u[2]
+        du3 = u[1]*u[2] - β*u[3]
+        return SVector{3}(du1, du2, du3)
+    end
+end
+function liip(du, u, p, t)
+    σ = p[1]; ρ = p[2]; β = p[3]
+    du[1] = σ*(u[2]-u[1])
+    du[2] = u[1]*(ρ-u[3]) - u[2]
+    du[3] = u[1]*u[2] - β*u[3]
+    return nothing
+end
+
+
+# %%
+begin
+    u0 = 10ones(3)
+
+    oop = init(MinimalTsit5(), loop, false, SVector{3}(u0), 0.0, 0.0001, [10, 28, 8/3])
+    step!(oop)
+    for i in 1:10000;
+        step!(oop);
+        if isnan(oop.u[1]) || isnan(oop.u[2]) || isnan(oop.u[3])
+            error("oop nan")
+        end
+    end
+
+    iip = init(MinimalTsit5(), liip, true, copy(u0), 0.0, 0.0001, [10, 28, 8/3])
+    step!(iip)
+    for i in 1:10000;
+        step!(iip);
+        if isnan(iip.u[1]) || isnan(iip.u[2]) || isnan(iip.u[3])
+            error("iip nan")
+        end
+    end
+
+    @profiler for i in 1:1000000; step!(iip); end
+
+end
+
+# @profiler for i in 1:1000000; step!(integ); end
+# using PyPlot
+#
+# for integ in (iip, oop)
+#     N = 10000
+#     xs = zeros(N); ys = copy(xs); zs = copy(xs)
+#
+#     for i in 1:N
+#         step!(integ)
+#         xs[i], ys[i], zs[i] = integ.u
+#     end
+#
+#     plot3D(xs, ys, zs)
+# end

--- a/src/simple_tsit5_integrator/profile_test.jl
+++ b/src/simple_tsit5_integrator/profile_test.jl
@@ -19,8 +19,8 @@ end
 # %%
 begin
     u0 = 10ones(3)
-
-    oop = init(MinimalTsit5(), loop, false, SVector{3}(u0), 0.0, 0.0001, [10, 28, 8/3])
+    dt = 0.01
+    oop = init(MinimalTsit5(), loop, false, SVector{3}(u0), 0.0, dt, [10, 28, 8/3])
     step!(oop)
     for i in 1:10000;
         step!(oop);
@@ -28,8 +28,9 @@ begin
             error("oop nan")
         end
     end
+    # @profiler for i in 1:1000000; step!(oop); end
 
-    iip = init(MinimalTsit5(), liip, true, copy(u0), 0.0, 0.0001, [10, 28, 8/3])
+    iip = init(MinimalTsit5(), liip, true, copy(u0), 0.0, dt, [10, 28, 8/3])
     step!(iip)
     for i in 1:10000;
         step!(iip);
@@ -37,22 +38,23 @@ begin
             error("iip nan")
         end
     end
-
-    @profiler for i in 1:1000000; step!(iip); end
-
+    # @profiler for i in 1:1000000; step!(iip); end
 end
 
-# @profiler for i in 1:1000000; step!(integ); end
-# using PyPlot
-#
-# for integ in (iip, oop)
-#     N = 10000
-#     xs = zeros(N); ys = copy(xs); zs = copy(xs)
-#
-#     for i in 1:N
-#         step!(integ)
-#         xs[i], ys[i], zs[i] = integ.u
-#     end
-#
-#     plot3D(xs, ys, zs)
-# end
+using PyPlot
+begin
+    u0 = 10ones(3)
+    oop = init(MinimalTsit5(), loop, false, SVector{3}(u0), 0.0, 0.01, [10, 28, 8/3])
+    iip = init(MinimalTsit5(), liip, true, copy(u0), 0.0, 0.01, [10, 28, 8/3])
+    N = 1000
+    for (j, integ) in enumerate((iip, oop))
+        xs = zeros(N); ys = copy(xs); zs = copy(xs)
+
+        for i in 1:N
+            step!(integ)
+            xs[i], ys[i], zs[i] = integ.u
+        end
+
+        plot3D(xs, ys, zs, ls = j==1 ? "solid" : "dashed")
+    end
+end

--- a/src/simple_tsit5_integrator/tsit5_integrator.jl
+++ b/src/simple_tsit5_integrator/tsit5_integrator.jl
@@ -4,18 +4,18 @@ import DiffEqBase: init, step!
 struct MinimalTsit5 end
 
 mutable struct MinimalTsit5Integrator{IIP, T, S <: AbstractVector{T}, P, F}
-    f::F                  # eom
-    uprev::S              # previous state
-    u::S                  # current state
-    tmp::S                # dummy, same as state
-    tprev::T              # previous time
-    t::T                  # current time
-    t0::T                 # initial time, only for reinit
-    dt::T                 # step size
-    p::P                  # parameter container
-    ks::Vector{S}         # interpolants of the algorithm
-    cs::SVector{6, T}     # ci factors cache
-    as::SVector{21, T}    # aij factors cache
+    f::F                      # eom
+    uprev::S                  # previous state
+    u::S                      # current state
+    tmp::S                    # dummy, same as state
+    tprev::T                  # previous time
+    t::T                      # current time
+    t0::T                     # initial time, only for reinit
+    dt::T                     # step size
+    p::P                      # parameter container
+    ks::Vector{S}             # interpolants of the algorithm
+    cs::SVector{6, T}         # ci factors cache
+    as::SVector{21, T}        # aij factors cache
 end
 
 function DiffEqBase.init(alg::MinimalTsit5, f::F, IIP::Bool, u0::S, t0::T, dt::T, p::P
@@ -38,39 +38,28 @@ function _build_caches(::MinimalTsit5, ::Type{T}) where {T}
     cs = SVector{6, T}(0.161, 0.327, 0.9, 0.9800255409045097, 1.0, 1.0)
 
     as = SVector{21, T}(
-    convert(T,0.161),
-    convert(T,-0.008480655492356989),
-    convert(T,0.335480655492357),
-    convert(T,2.8971530571054935),
-    convert(T,-6.359448489975075),
-    convert(T,4.3622954328695815),
-    convert(T,5.325864828439257),
-    convert(T,-11.748883564062828),
-    convert(T,7.4955393428898365),
-    convert(T,-0.09249506636175525),
-    convert(T,5.86145544294642),
-    convert(T,-12.92096931784711),
-    convert(T,8.159367898576159),
-    convert(T,-0.071584973281401),
-    convert(T,-0.028269050394068383),
-    convert(T,0.09646076681806523),
-    convert(T,0.01),
-    convert(T,0.4798896504144996),
-    convert(T,1.379008574103742),
-    convert(T,-3.290069515436081),
-    convert(T,2.324710524099774))
-
-    #btilde1 = convert(T,-0.00178001105222577714)
-    #btilde2 = convert(T,-0.0008164344596567469)
-    #btilde3 = convert(T,0.007880878010261995)
-    #btilde4 = convert(T,-0.1447110071732629)
-    #btilde5 = convert(T,0.5823571654525552)
-    #btilde6 = convert(T,-0.45808210592918697)
-    #btilde7 = convert(T,0.015151515151515152)
-
-    # see here for interpolation
-    # https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/blob/master/src/dense/interpolants.jl#L254-L270
-    # evalpoly is "something like"  ((((2+x)x+5)x+6)x+2)x+1
+        convert(T,0.161),                    # a21
+        convert(T,-0.008480655492356989),    # a31
+        convert(T,0.335480655492357),        # ⋮
+        convert(T,2.8971530571054935),
+        convert(T,-6.359448489975075),
+        convert(T,4.3622954328695815),
+        convert(T,5.325864828439257),
+        convert(T,-11.748883564062828),
+        convert(T,7.4955393428898365),
+        convert(T,-0.09249506636175525),
+        convert(T,5.86145544294642),
+        convert(T,-12.92096931784711),
+        convert(T,8.159367898576159),
+        convert(T,-0.071584973281401),
+        convert(T,-0.028269050394068383),
+        convert(T,0.09646076681806523),
+        convert(T,0.01),
+        convert(T,0.4798896504144996),
+        convert(T,1.379008574103742),
+        convert(T,-3.290069515436081),
+        convert(T,2.324710524099774)         # a76
+    )
 
     return cs, as
 end
@@ -159,61 +148,3 @@ function DiffEqBase.step!(integ::MinimalTsit5Integrator{false, T, S}) where {T, 
 
     return  nothing
 end
-
-function loop(u, p, t)
-    @inbounds begin
-        σ = p[1]; ρ = p[2]; β = p[3]
-        du1 = σ*(u[2]-u[1])
-        du2 = u[1]*(ρ-u[3]) - u[2]
-        du3 = u[1]*u[2] - β*u[3]
-        return SVector{3}(du1, du2, du3)
-    end
-end
-function liip(du, u, p, t)
-    σ = p[1]; ρ = p[2]; β = p[3]
-    du[1] = σ*(u[2]-u[1])
-    du[2] = u[1]*(ρ-u[3]) - u[2]
-    du[3] = u[1]*u[2] - β*u[3]
-    return nothing
-end
-
-# %%
-begin
-    u0 = 10ones(3)
-
-    oop = init(MinimalTsit5(), loop, false, SVector{3}(u0), 0.0, 0.0001, [10, 28, 8/3])
-    step!(oop)
-    for i in 1:10000;
-        step!(oop);
-        if isnan(oop.u[1]) || isnan(oop.u[2]) || isnan(oop.u[3])
-            error("oop nan")
-        end
-    end
-
-    iip = init(MinimalTsit5(), liip, true, copy(u0), 0.0, 0.0001, [10, 28, 8/3])
-    step!(iip)
-    for i in 1:10000;
-        step!(iip);
-        if isnan(iip.u[1]) || isnan(iip.u[2]) || isnan(iip.u[3])
-            error("iip nan")
-        end
-    end
-
-    @profiler for i in 1:1000000; step!(iip); end
-
-end
-
-# @profiler for i in 1:1000000; step!(integ); end
-# using PyPlot
-#
-# for integ in (iip, oop)
-#     N = 10000
-#     xs = zeros(N); ys = copy(xs); zs = copy(xs)
-#
-#     for i in 1:N
-#         step!(integ)
-#         xs[i], ys[i], zs[i] = integ.u
-#     end
-#
-#     plot3D(xs, ys, zs)
-# end

--- a/src/simple_tsit5_integrator/tsit5_integrator.jl
+++ b/src/simple_tsit5_integrator/tsit5_integrator.jl
@@ -140,6 +140,7 @@ function step!(integ::MinimalTsit5Integrator{true, T, S}) where {T, S}
     end
     f!(k7, integ.u, p, t+dt)
 
+    integ.tprev = t
     integ.t += dt
 
     return  nothing
@@ -177,6 +178,7 @@ function step!(integ::MinimalTsit5Integrator{false, T, S}) where {T, S}
         integ.ks[4] = k4; integ.ks[5] = k5; integ.ks[6] = k6
     end
 
+    integ.tprev = t
     integ.t += dt
 
     return  nothing
@@ -186,7 +188,7 @@ end
 # Interpolation
 #######################################################################################
 # Interpolation function, OOP
-function (integ::MinimalTsit5)(t::T) where {T}
+function (integ::MinimalTsit5Integrator)(t::T) where {T}
     tnext, tprev, dt = integ.t, integ.tprev, integ.dt
     @assert tprev ≤ t ≤ tnext
     θ = (t - tprev)/dt

--- a/src/simple_tsit5_integrator/tsit5_integrator.jl
+++ b/src/simple_tsit5_integrator/tsit5_integrator.jl
@@ -1,5 +1,5 @@
 using StaticArrays
-import DiffEqBase: init, step!, isinplace
+import DiffEqBase
 
 struct MinimalTsit5 end
 
@@ -19,12 +19,12 @@ mutable struct MinimalTsit5Integrator{IIP, T, S <: AbstractVector{T}, P, F}
     rs::SVector{22, T}    # rij factors cache: interpolation coefficients
 end
 
-isinplace(::MinimalTsit5Integrator{IIP}) where {IIP} = IIP
+DiffEqBase.isinplace(::MinimalTsit5Integrator{IIP}) where {IIP} = IIP
 
 #######################################################################################
 # Initialization
 #######################################################################################
-function init(alg::MinimalTsit5, f::F, IIP::Bool, u0::S, t0::T, dt::T, p::P
+function DiffEqBase.init(alg::MinimalTsit5, f::F, IIP::Bool, u0::S, t0::T, dt::T, p::P
     ) where {F, P, T, S<:AbstractArray{T}}
 
     cs, as, rs = _build_caches(alg, T)
@@ -99,7 +99,7 @@ end
 # Stepping
 #######################################################################################
 # IIP version for vectors and matrices
-function step!(integ::MinimalTsit5Integrator{true, T, S}) where {T, S}
+function DiffEqBase.step!(integ::MinimalTsit5Integrator{true, T, S}) where {T, S}
 
     L = length(integ.u)
 
@@ -147,7 +147,7 @@ function step!(integ::MinimalTsit5Integrator{true, T, S}) where {T, S}
 end
 
 # OOP version for vectors and matrices
-function step!(integ::MinimalTsit5Integrator{false, T, S}) where {T, S}
+function DiffEqBase.step!(integ::MinimalTsit5Integrator{false, T, S}) where {T, S}
 
     c1, c2, c3, c4, c5, c6 = integ.cs;
     dt = integ.dt; t = integ.t; p = integ.p


### PR DESCRIPTION
To-dos

- [x] Change all broadcasts to `for` loops, as instructed by @YingboMa 
- [x] Add interpolation (valid between `tprev` and `t`)
- [x] Hook it up to `DiffEqBase`
- [x] Think about what to do with the adaptive step, by comparing with existing DiffEq code using different norms
- [x] Add tests
- [x] Allow modifying current state
- [ ] Do proper benchmarks

*I will be copying this code to `DynamicalSystemsBase` as well, as I intend to move the `DiffEq` dependency to `DynamicalSystems` behind `@require`*

Then, I'll also add step methods for `Vector{Vector}` and `Vector{SVector}`.

Edit: here is how adaptive is _currently_ done: 
https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/blob/master/src/integrators/integrator_utils.jl#L156-L179
https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/blob/master/src/integrators/integrator_utils.jl#L292-L350
https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/blob/master/src/integrators/integrator_utils.jl#L7-L25
(it's not going to be a simple copy-paste)