### PR TITLE
Add keyword support to SimpleAtsit5()

### DIFF
--- a/src/tsit5/atsit5.jl
+++ b/src/tsit5/atsit5.jl
@@ -2,6 +2,9 @@ struct SimpleATsit5 end
 
 const beta1 = 7/50
 const beta2 = 2/25
+const qmax = 10.0
+const qmin = 1/5
+const gamma = 9/10
 
 mutable struct SimpleATsit5Integrator{IIP, T, S <: AbstractVector{T}, P, F} <: DiffEqBase.DEIntegrator
     f::F                  # eom
@@ -20,11 +23,8 @@ mutable struct SimpleATsit5Integrator{IIP, T, S <: AbstractVector{T}, P, F} <: D
     as::SVector{21, T}    # aij factors cache: solution coefficients
     btildes::SVector{7,T}
     rs::SVector{22, T}    # rij factors cache: interpolation coefficients
-    gamma::Float64
     qold::Float64
     qoldinit::Float64
-    qmax::Float64
-    qmin::Float64
     abstol::Float64
     reltol::Float64
 end
@@ -72,17 +72,14 @@ function simpleatsit5_init(f::F,
 
     !IIP && @assert S <: SArray
 
-    gamma = 9/10
     qold = 1e-4
-    qmax = 10.0
-    qmin = 1/5
     abstol = 1e-6
     reltol = 1e-3
 
     integ = SAT5I{IIP, T, S, P, F}(
         f, copy(u0), copy(u0), copy(u0), t0, t0, t0, tf, dt,
         p, true, ks, cs, as, btildes, rs,
-        gamma,qold,qold,qmax,qmin,abstol,reltol
+        qold,qold,abstol,reltol
     )
 end
 
@@ -171,11 +168,8 @@ function DiffEqBase.step!(integ::SAT5I{true, T, S}) where {T, S}
 
     integ.uprev .= integ.u; uprev = integ.uprev; u = integ.u
 
-    gamma = integ.gamma
     qold = integ.qold
     qoldinit = integ.qoldinit
-    qmax = integ.qmax
-    qmin = integ.qmin
     abstol = integ.abstol
     reltol = integ.reltol
 
@@ -268,11 +262,8 @@ function DiffEqBase.step!(integ::SAT5I{false, T, S}) where {T, S}
     tmp = integ.tmp; f = integ.f
     integ.uprev = integ.u; uprev = integ.u
 
-    gamma = integ.gamma
     qold = integ.qold
     qoldinit = integ.qoldinit
-    qmax = integ.qmax
-    qmin = integ.qmin
     abstol = integ.abstol
     reltol = integ.reltol
 

--- a/src/tsit5/atsit5.jl
+++ b/src/tsit5/atsit5.jl
@@ -1,5 +1,8 @@
 struct SimpleATsit5 end
 
+const beta1 = 7/50
+const beta2 = 2/25
+
 mutable struct SimpleATsit5Integrator{IIP, T, S <: AbstractVector{T}, P, F} <: DiffEqBase.DEIntegrator
     f::F                  # eom
     uprev::S              # previous state
@@ -22,8 +25,6 @@ mutable struct SimpleATsit5Integrator{IIP, T, S <: AbstractVector{T}, P, F} <: D
     qoldinit::Float64
     qmax::Float64
     qmin::Float64
-    beta1::Float64
-    beta2::Float64
     abstol::Float64
     reltol::Float64
 end
@@ -75,15 +76,13 @@ function simpleatsit5_init(f::F,
     qold = 1e-4
     qmax = 10.0
     qmin = 1/5
-    beta1 = 7/50
-    beta2 = 2/25
     abstol = 1e-6
     reltol = 1e-3
 
     integ = SAT5I{IIP, T, S, P, F}(
         f, copy(u0), copy(u0), copy(u0), t0, t0, t0, tf, dt,
         p, true, ks, cs, as, btildes, rs,
-        gamma,qold,qold,qmax,qmin,beta1,beta2,abstol,reltol
+        gamma,qold,qold,qmax,qmin,abstol,reltol
     )
 end
 
@@ -177,8 +176,6 @@ function DiffEqBase.step!(integ::SAT5I{true, T, S}) where {T, S}
     qoldinit = integ.qoldinit
     qmax = integ.qmax
     qmin = integ.qmin
-    beta1 = integ.beta1
-    beta2 = integ.beta2
     abstol = integ.abstol
     reltol = integ.reltol
 
@@ -276,8 +273,6 @@ function DiffEqBase.step!(integ::SAT5I{false, T, S}) where {T, S}
     qoldinit = integ.qoldinit
     qmax = integ.qmax
     qmin = integ.qmin
-    beta1 = integ.beta1
-    beta2 = integ.beta2
     abstol = integ.abstol
     reltol = integ.reltol
 

--- a/src/tsit5/atsit5.jl
+++ b/src/tsit5/atsit5.jl
@@ -5,6 +5,7 @@ const beta2 = 2/25
 const qmax = 10.0
 const qmin = 1/5
 const gamma = 9/10
+const qoldinit = 1e-4
 
 mutable struct SimpleATsit5Integrator{IIP, T, S <: AbstractVector{T}, P, F} <: DiffEqBase.DEIntegrator
     f::F                  # eom
@@ -24,7 +25,6 @@ mutable struct SimpleATsit5Integrator{IIP, T, S <: AbstractVector{T}, P, F} <: D
     btildes::SVector{7,T}
     rs::SVector{22, T}    # rij factors cache: interpolation coefficients
     qold::Float64
-    qoldinit::Float64
     abstol::Float64
     reltol::Float64
 end
@@ -72,14 +72,13 @@ function simpleatsit5_init(f::F,
 
     !IIP && @assert S <: SArray
 
-    qold = 1e-4
     abstol = 1e-6
     reltol = 1e-3
 
     integ = SAT5I{IIP, T, S, P, F}(
         f, copy(u0), copy(u0), copy(u0), t0, t0, t0, tf, dt,
         p, true, ks, cs, as, btildes, rs,
-        qold,qold,abstol,reltol
+        qoldinit,qoldinit,abstol,reltol
     )
 end
 
@@ -169,7 +168,6 @@ function DiffEqBase.step!(integ::SAT5I{true, T, S}) where {T, S}
     integ.uprev .= integ.u; uprev = integ.uprev; u = integ.u
 
     qold = integ.qold
-    qoldinit = integ.qoldinit
     abstol = integ.abstol
     reltol = integ.reltol
 
@@ -263,7 +261,6 @@ function DiffEqBase.step!(integ::SAT5I{false, T, S}) where {T, S}
     integ.uprev = integ.u; uprev = integ.u
 
     qold = integ.qold
-    qoldinit = integ.qoldinit
     abstol = integ.abstol
     reltol = integ.reltol
 

--- a/test/simpleatsit5_tests.jl
+++ b/test/simpleatsit5_tests.jl
@@ -31,13 +31,13 @@ step!(iip); step!(iip)
 
 deoop = DiffEqBase.init(odeoop, Tsit5(); dt = dt)
 step!(deoop); step!(deoop)
-@test oop.u ≈ deoop.u atol=1e-14
-@test oop.t ≈ deoop.t atol=1e-14
+@test oop.u ≈ deoop.u atol=1e-9
+@test oop.t ≈ deoop.t atol=1e-9
 
 deiip = DiffEqBase.init(odeiip, Tsit5(); dt = dt)
 step!(deiip); step!(deiip)
 @test iip.u ≈ deiip.u atol=1e-9
-@test iip.t ≈ deiip.t atol=1e-12
+@test iip.t ≈ deiip.t atol=1e-9
 
 sol = solve(odeoop,SimpleATsit5(),dt=dt)
 
@@ -47,8 +47,8 @@ step!(oop); step!(oop)
 deoop = DiffEqBase.init(odeoop, Tsit5(); dt = dt, reltol=1e-9, abstol=1e-9)
 step!(deoop); step!(deoop)
 
-@test oop.u ≈ deoop.u atol=1e-14
-@test oop.t ≈ deoop.t atol=1e-14
+@test oop.u ≈ deoop.u atol=1e-9
+@test oop.t ≈ deoop.t atol=1e-9
 
 ###################################################################################
 # Internal norm test:
@@ -77,5 +77,5 @@ step!(oop); step!(oop)
 iip = init(odemiip,SimpleATsit5(),dt=dt, internalnorm = u -> norm(u[:, 1]))
 step!(iip); step!(iip)
 
-@test oop.u ≈ iip.u atol=1e-14
-@test oop.t ≈ iip.t atol=1e-14
+@test oop.u ≈ iip.u atol=1e-9
+@test oop.t ≈ iip.t atol=1e-9

--- a/test/simpleatsit5_tests.jl
+++ b/test/simpleatsit5_tests.jl
@@ -59,15 +59,15 @@ function moop(u, p, t)
 end
 function miip(du, u, p, t)
     @views begin
-        luup(du[:, 1], u[:, 1], p, t)
-        luup(du[:, 2], u[:, 2], p, t)
+        liip(du[:, 1], u[:, 1], p, t)
+        liip(du[:, 2], u[:, 2], p, t)
     end
     return nothing
 end
 
 ran = rand(SVector{3})
-odemoop = ODEProblem{false}(loop, SMatrix{3,2}(hcat(u0, ran)), (0.0, 100.0),  [10, 28, 8/3])
-odemiip = ODEProblem{true}(liip, hcat(u0, ran), (0.0, 100.0),  [10, 28, 8/3])
+odemoop = ODEProblem{false}(moop, SMatrix{3,2}(hcat(u0, ran)), (0.0, 100.0),  [10, 28, 8/3])
+odemiip = ODEProblem{true}(miip, hcat(u0, ran), (0.0, 100.0),  [10, 28, 8/3])
 
 using LinearAlgebra
 

--- a/test/simpleatsit5_tests.jl
+++ b/test/simpleatsit5_tests.jl
@@ -77,12 +77,5 @@ step!(oop); step!(oop)
 iip = init(odemiip,SimpleATsit5(),dt=dt, internalnorm = u -> norm(u[:, 1]))
 step!(iip); step!(iip)
 
-deoop = DiffEqBase.init(odeoop, Tsit5(); dt = dt, internalnorm = u -> norm(u[:, 1]))
-step!(deoop); step!(deoop)
-@test oop.u ≈ deoop.u atol=1e-14
-@test oop.t ≈ deoop.t atol=1e-14
-
-deiip = DiffEqBase.init(odeiip, Tsit5(); dt = dt, internalnorm = u -> norm(u[:, 1]))
-step!(deiip); step!(deiip)
-@test iip.u ≈ deiip.u atol=1e-9
-@test iip.t ≈ deiip.t atol=1e-12
+@test oop.u ≈ iip.u atol=1e-14
+@test oop.t ≈ iip.t atol=1e-14

--- a/test/simpleatsit5_tests.jl
+++ b/test/simpleatsit5_tests.jl
@@ -40,3 +40,12 @@ step!(deiip); step!(deiip)
 @test iip.t ≈ deiip.t atol=1e-12
 
 sol = solve(odeoop,SimpleATsit5(),dt=dt)
+
+# Test keywords:
+oop = init(odeoop,SimpleATsit5(),dt=dt, reltol = 1e-9, abstol = 1e-9)
+step!(oop); step!(oop)
+deoop = DiffEqBase.init(odeoop, Tsit5(); dt = dt, reltol=1e-9, abstol=1e-9)
+step!(deoop); step!(deoop)
+
+@test oop.u ≈ deoop.u atol=1e-14
+@test oop.t ≈ deoop.t atol=1e-14


### PR DESCRIPTION
This PR makes all adaptive PI stepping parameters constants, besides abs/rel tol. They are instead made keyword arguments for the integrator.

In addition, one more keyword argument (the internalnorm) is added.

Closes #11