### PR TITLE
correct interpolation signature

### DIFF
--- a/src/tsit5/atsit5.jl
+++ b/src/tsit5/atsit5.jl
@@ -586,7 +586,7 @@ end
 # Interpolation
 #######################################################################################
 # Interpolation function, both OOP and IIP
-function (integ::SAT5I{IIP, S, T})(t::Real) where {IIP, S, T<:AbstractArray{<:Number}}
+function (integ::SAT5I{IIP, S, T})(t::Real) where {IIP, S<:AbstractArray{<:Number}, T}
     tnext, tprev, dt = integ.t, integ.tprev, integ.dt
     @assert tprev ≤ t ≤ tnext
     θ = (t - tprev)/dt


### PR DESCRIPTION
I have forgotten to change this signature and `integ(t)` wouldn't work. Now it does.