### PR TITLE
Remove assertion check in interpolation

### DIFF
--- a/src/tsit5/atsit5.jl
+++ b/src/tsit5/atsit5.jl
@@ -525,7 +525,7 @@ end
 # Interpolation function, both OOP and IIP
 function (integ::SAT5I{IIP, S, T})(t::Real) where {IIP, S<:AbstractArray{<:Number}, T}
     tnext, tprev, dt = integ.t, integ.tprev, integ.dt
-    @assert tprev ≤ t ≤ tnext
+
     θ = (t - tprev)/dt
     b1θ, b2θ, b3θ, b4θ, b5θ, b6θ, b7θ = bθs(integ.rs, θ)
 


### PR DESCRIPTION
To the best of my memory, the Tsit5 interpolation allows a bit of extrapolation (which of course has large errors if you extrapolate by a lot).

But for times just slightly over `t` extrapolation should be fine, no? The assertion error forbids it.