### PR TITLE
Update SimpleATsit5 to new internalnorm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,22 @@
+name = "SimpleDiffEq"
+uuid = "05bca326-078c-5bf0-a5bf-ce7c7982d7fd"
+repo = "https://github.com/JuliaDiffEq/SimpleDiffEq.jl.git"
+version = "0.4.0"
+
+[deps]
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[compat]
+DiffEqBase = "5.0.0"
+StaticArrays = "≥ 0.8.0"
+julia = "≥ 1.0.0"
+
+[extras]
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["OrdinaryDiffEq", "Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,0 @@
-julia 1.0
-DiffEqBase 5.0
-Reexport
-StaticArrays
-RecursiveArrayTools

--- a/src/tsit5/gpuatsit5.jl
+++ b/src/tsit5/gpuatsit5.jl
@@ -126,7 +126,7 @@ function DiffEqBase.solve(prob::ODEProblem,
         tmp = dt*(btilde1*k1+btilde2*k2+btilde3*k3+btilde4*k4+
                      btilde5*k5+btilde6*k6+btilde7*k7)
         tmp = tmp./(abstol+max.(abs.(uprev),abs.(u))*reltol)
-        EEst = defaultnorm(tmp)
+        EEst = DiffEqBase.ODE_DEFAULT_NORM(tmp, t)
 
         if iszero(EEst)
           q = inv(qmax)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,0 @@
-DiffEqProblemLibrary 1.0.0
-OrdinaryDiffEq

--- a/test/simpleatsit5_tests.jl
+++ b/test/simpleatsit5_tests.jl
@@ -117,10 +117,10 @@ odemiip = ODEProblem{true}(miip, hcat(u0, ran), (0.0, 100.0),  [10, 28, 8/3])
 
 using LinearAlgebra
 
-oop = init(odemoop,SimpleATsit5(),dt=dt, internalnorm = u -> norm(u[:, 1]))
+oop = init(odemoop,SimpleATsit5(),dt=dt, internalnorm = (u, t) -> norm(u[:, 1]))
 step!(oop); step!(oop)
 
-iip = init(odemiip,SimpleATsit5(),dt=dt, internalnorm = u -> norm(u[:, 1]))
+iip = init(odemiip,SimpleATsit5(),dt=dt, internalnorm = (u, t) -> norm(u[:, 1]))
 step!(iip); step!(iip)
 
 @test oop.u ≈ iip.u atol=1e-9
@@ -145,7 +145,7 @@ ran = rand(3)
 odevoop = ODEProblem{true}(vvoop, [SVector{3}(u0),  SVector{3}(ran)], (0.0, 100.0),  [10, 28, 8/3])
 odeviip = ODEProblem{true}(vviip, [u0, ran], (0.0, 100.0),  [10, 28, 8/3])
 
-viip = init(odeviip,SimpleATsit5(),dt=dt; internalnorm = u -> SimpleDiffEq.defaultnorm(u[1]))
+viip = init(odeviip,SimpleATsit5(),dt=dt; internalnorm = (u, t) -> DiffEqBase.ODE_DEFAULT_NORM(u[1], t))
 step!(viip); step!(viip)
 
 iip = init(odeiip,SimpleATsit5(),dt=dt)
@@ -153,7 +153,7 @@ step!(iip); step!(iip)
 
 @test iip.u ≈ viip.u[1] atol=1e-9
 
-voop = init(odevoop,SimpleATsit5(),dt=dt,internalnorm = u -> SimpleDiffEq.defaultnorm(u[1]))
+voop = init(odevoop,SimpleATsit5(),dt=dt,internalnorm = (u, t) -> DiffEqBase.ODE_DEFAULT_NORM(u[1], t))
 step!(voop); step!(voop)
 
 oop = init(odeoop,SimpleATsit5(),dt=dt)


### PR DESCRIPTION
This updates SimpleATsit5 to the new internal norm changes that were discussed in : https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/569

This PR is necessary for **DynamicalSystems.jl** to take advantage of the changes.

Since I was at it anyway, I also updated the repo to Project.toml file.

The tests pass for SimpleATsit5, but GPUTsit, which falls beyond the scope of this PR, fails.